### PR TITLE
Use a comma by default for CSV transposition

### DIFF
--- a/autoload/transpose.vim
+++ b/autoload/transpose.vim
@@ -140,7 +140,7 @@ function transpose#csv(first_line, last_line, ...)
   if a:0 > 2
     throw 'Optional arguments: separator, delimiter. Only 2 allowed.'
   endif
-  let separator = (a:0 > 0) ? a:1 : ';'
+  let separator = (a:0 > 0) ? a:1 : ','
   let delimiter = (a:0 > 1) ? a:2 : ''
   call transpose#delimited(a:first_line, a:last_line, separator, delimiter)
 endfunction " }}}


### PR DESCRIPTION
Change the separator for CSV transpose to comma
